### PR TITLE
Changed GetAllStrings() to return all strings for the current culture.

### DIFF
--- a/src/DbLocalizationProvider.AspNetCore/DbStringLocalizer.cs
+++ b/src/DbLocalizationProvider.AspNetCore/DbStringLocalizer.cs
@@ -24,7 +24,9 @@ namespace DbLocalizationProvider.AspNetCore
 
         public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures)
         {
-            return Enumerable.Empty<LocalizedString>();
+            var values = _culture != null ? LocalizationProvider.Current.GetStringsByCulture(_culture) : LocalizationProvider.Current.GetStringsByCulture(CultureInfo.CurrentUICulture);
+
+            return values.Select(value => new LocalizedString(value.Key, value.Value??value.Key, value.Value == null));
         }
 
         public IStringLocalizer WithCulture(CultureInfo culture)


### PR DESCRIPTION
Hello,

Makes use of the new LocalizationProvider.GetStringsByCulture(...) function to retrieve all strings for the current language.
Complementary to the #188 Pull request (LocalizationProvider).

Kind regards,
Laurent.